### PR TITLE
update markup for Victoire 2.3 compatibility

### DIFF
--- a/Resources/js/pictureComparator.js
+++ b/Resources/js/pictureComparator.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function($){
-    $(".vic-widget-picturecomparator .twentytwenty-container").each(function() {
+    $(".v-widget--picturecomparator .twentytwenty-container").each(function() {
         var orientation = 'horizontal';
         var initialOffset = 0.5;
         var beforeLabel = "Before";
@@ -18,7 +18,7 @@ jQuery(document).ready(function($){
             afterLabel = $(this).attr('data-after-label');
         }
 
-        $(this).twentytwenty({
+        $vic(this).twentytwenty({
             'orientation': orientation,
             'default_offset_pct': initialOffset,
             'before_label': beforeLabel,

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.3",
-        "victoire/victoire": ">=2.0.0|~3.0"
+        "victoire/victoire": ">=2.3.0|~3.0"
     },
     "autoload": {
         "psr-0": { "Victoire\\Widget\\PictureComparatorBundle": "" }


### PR DESCRIPTION
The markup of widget and jquery are changed in Victoire 2.3, we must update too but this changes aren't compatible with older Victoire version.